### PR TITLE
Added CascadingAuthenticationState to App.razor.

### DIFF
--- a/BlazorWithIdentity.Client/App.razor
+++ b/BlazorWithIdentity.Client/App.razor
@@ -3,8 +3,10 @@
         <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
     </Found>
     <NotFound>
-        <LayoutView Layout="@typeof(MainLayout)">
-            <p>Sorry, there's nothing at this address.</p>
-        </LayoutView>
+        <CascadingAuthenticationState>
+            <LayoutView Layout="@typeof(MainLayout)">
+                <p>Sorry, there's nothing at this address.</p>
+            </LayoutView>
+        </CascadingAuthenticationState>
     </NotFound>
 </Router>


### PR DESCRIPTION
This fixes the following console error:

System.InvalidOperationException: Authorization requires a cascading parameter of type Task<AuthenticationState>. Consider using CascadingAuthenticationState to supply this.

Without it, users that are not logged in and hit a 404 will find that the client has crashed and it will not be redirected to the login page.