### PR TITLE
There's an issue with the login of users who have more than one role …

### DIFF
--- a/template/BlazorWithIdentity.Server/Controllers/AuthorizeController.cs
+++ b/template/BlazorWithIdentity.Server/Controllers/AuthorizeController.cs
@@ -73,7 +73,8 @@ namespace BlazorWithIdentity.Server.Controllers
                 ExposedClaims = User.Claims
                     //Optionally: filter the claims you want to expose to the client
                     //.Where(c => c.Type == "test-claim")
-                    .ToDictionary(c => c.Type, c => c.Value)
+                    .GroupBy(c => c.Type)
+                    .ToDictionary(g => g.Key, g => string.Join(", ", g.Select(c => c.Value))),
             };
         }
     }


### PR DESCRIPTION
There's an issue with the login of users who have more than one role assigned. To address the "An item with the same key has already been added" error, we need to adjust ExposedClaims.

Solution:
ExposedClaims = this.User.Claims.GroupBy(c => c.Type).ToDictionary(g => g.Key, g => string.Join(", ", g.Select(c => c.Value))),